### PR TITLE
Refactored 3D code base

### DIFF
--- a/capstone/data/data_module.py
+++ b/capstone/data/data_module.py
@@ -6,8 +6,8 @@ from multiprocessing import cpu_count
 from typing import List, Optional, Union
 
 import pytorch_lightning as pl
-from capstone.data.datasets import get_miccai_2d
-from capstone.transforms import predefined
+from capstone.data.datasets import get_miccai_2d, get_miccai_3d
+from capstone.transforms import predefined, predefined_3d
 from torch.utils.data import DataLoader
 
 DEGREE = {
@@ -16,6 +16,8 @@ DEGREE = {
     3: predefined.windowed_degree_3,
     4: predefined.windowed_degree_4,
 }
+
+DEGREE_3D = {0: predefined_3d.windowed_degree_0}
 
 
 class MiccaiDataModule2D(pl.LightningDataModule):
@@ -63,5 +65,51 @@ class MiccaiDataModule2D(pl.LightningDataModule):
             batch_size=self.batch_size,
             shuffle=False,
             num_workers=cpu_count(),
+            pin_memory=True,
+        )
+
+
+class MiccaiDataModule3D(pl.LightningDataModule):
+    def __init__(self, batch_size, transform_degree: int = None, **kwargs):
+        super().__init__()
+        self.batch_size = batch_size
+        assert transform_degree in DEGREE_3D.keys(), "Invalid transform degree passed"
+        self.transform = DEGREE_3D[transform_degree]
+
+    def setup(self, stage: Optional[str]):
+        if stage == "fit" or stage is None:
+            self.train_dataset = get_miccai_3d(
+                split="train", transform=self.transform["train"],
+            )
+            self.val_dataset = get_miccai_3d(
+                split="valid", transform=self.transform["test"],
+            )
+
+        if stage == "test" or stage is None:
+            self.test_dataset = get_miccai_3d(
+                split="test", transform=self.transform["test"],
+            )
+
+    def train_dataloader(self) -> DataLoader:
+        return DataLoader(
+            self.train_dataset,
+            batch_size=self.batch_size,
+            shuffle=True,
+            pin_memory=True,
+        )
+
+    def val_dataloader(self) -> Union[DataLoader, List[DataLoader]]:
+        return DataLoader(
+            self.val_dataset,
+            batch_size=self.batch_size,
+            shuffle=False,
+            pin_memory=True,
+        )
+
+    def test_dataloader(self) -> Union[DataLoader, List[DataLoader]]:
+        return DataLoader(
+            self.test_dataset,
+            batch_size=self.batch_size,
+            shuffle=False,
             pin_memory=True,
         )

--- a/capstone/data/datasets.py
+++ b/capstone/data/datasets.py
@@ -54,8 +54,55 @@ class MiccaiDataset2D(Dataset):
         return image, masks, mask_indicator
 
 
+class MiccaiDataset3D(Dataset):
+    def __init__(self, path: str, transform=None) -> None:
+        self.path = Path(path).absolute()
+        self.transform = transform
+
+        self.instance_paths = []
+        for instance in self.path.iterdir():
+            self.instance_paths.append(instance.as_posix())
+        self.instance_paths.sort()  # To get same order on Windows and Linux (cluster)
+
+    def __len__(self) -> int:
+        return len(self.instance_paths)
+
+    def __getitem__(self, index: int) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+        instance = np.load(self.instance_paths[index])
+        image = instance["image"]  # Image : 1xDxHxW
+        masks, mask_indicator = (
+            instance["masks"],
+            instance["mask_indicator"],
+        )  # Masks : 9xDxHxW
+
+        assert len(mask_indicator) == len(miccai.STRUCTURES)
+        assert masks.shape[0] == len(miccai.STRUCTURES)
+
+        masks = list(masks)
+        if self.transform is not None:
+            transformed = self.transform(
+                image=image, masks=masks
+            )  # TO DO: Add 3 new channels!
+            image = transformed["image"]  # Image : 1xHxWxD (1x256x256x96 usually)
+            masks = transformed["masks"]
+
+        masks = torch.from_numpy(
+            np.stack(masks)
+        )  # Masks : 9xHxWxD (9x256x256x96 usually)
+        mask_indicator = torch.from_numpy(mask_indicator)
+
+        return image, masks, mask_indicator
+
+
 def get_miccai_2d(split: str = "train", transform=None) -> Dataset:
     assert split in ["train", "valid", "test"], "Invalid data split passed"
     path = DEFAULT_DATA_STORAGE + f"/miccai_2d/{split}"
 
     return MiccaiDataset2D(path, transform=transform)
+
+
+def get_miccai_3d(split: str = "train", transform=None) -> Dataset:
+    assert split in ["train", "valid", "test"], "Invalid data split passed"
+    path = DEFAULT_DATA_STORAGE + f"/miccai_3d/{split}"
+
+    return MiccaiDataset3D(path, transform=transform)

--- a/capstone/data/process_miccai.py
+++ b/capstone/data/process_miccai.py
@@ -27,6 +27,27 @@ def convert_to_2d(
     )
 
 
+def convert_to_3d(
+    read_dir: str, save_dir: str, split: str = None, crop: bool = True,
+) -> None:
+    """TODO
+
+    """
+    read_location = Path(read_dir)
+    save_location = Path(save_dir)
+    if split is not None:
+        read_location = read_location / split
+        save_location = save_location / split
+
+    save_location.mkdir(parents=True, exist_ok=True)
+    read_location = read_location.as_posix()
+
+    patient_collection = miccai.PatientCollection(read_location)
+    _ = patient_collection.apply_function(
+        _patient_to_3d, save_location=save_location, crop=crop,
+    )
+
+
 def _patient_to_2d(
     patient: miccai.Patient, save_location: Path, crop: bool = True,
 ) -> None:
@@ -72,6 +93,44 @@ def _patient_to_2d(
             )
 
 
+def _patient_to_3d(
+    patient: miccai.Patient, save_location: Path, crop: bool = True,
+) -> None:
+    """TODO
+    """
+    temp_patient = patient
+    if crop:
+        temp_patient.crop_data()
+    patient_id = Path(temp_patient.patient_dir).stem
+    vol = temp_patient.image.as_numpy()
+
+    region_slides = []
+    mask_indicator = np.ones(len(miccai.STRUCTURES))
+    all_zeros = np.zeros_like(
+        vol[0, :, :, :], dtype="uint8"
+    )  # Dummy mask. Shape: (D, H, W)
+    for i, structure in enumerate(miccai.STRUCTURES):
+        region_volume = temp_patient.structures[structure]
+        if region_volume is not None:
+            region_slide = region_volume.as_numpy()[0, :, :, :]  # Shape: (D, H, W)
+        else:
+            region_slide = all_zeros
+            mask_indicator[i] = 0
+        region_slides.append(region_slide)
+
+    region_slides = np.stack(
+        region_slides
+    )  # Shape: (9, D, H, W) -> 1 mask for each structure
+
+    # Ignore the slide if there is no structure (BrainStem, etc) present
+    # It's useless since there's nothing to train/validate on
+    if region_slides.sum() > 0:
+        filename = (save_location / f"{patient_id}.npz").as_posix()
+        np.savez(
+            filename, image=vol, masks=region_slides, mask_indicator=mask_indicator,
+        )
+
+
 if __name__ == "__main__":
     parser = ArgumentParser()
     subparsers = parser.add_subparsers(help="Process MICCAI", dest="command")
@@ -102,14 +161,44 @@ if __name__ == "__main__":
         help="Don't apply the cropping mechanism to volumes before converting",
     )
 
+    convert_3d_parser = subparsers.add_parser("convert_3d")
+    convert_3d_parser.add_argument(
+        "--root_dir",
+        type=str,
+        default=None,
+        help="Root directory where the train, valid and test splits of MICCAI reside",
+    )
+    convert_3d_parser.add_argument(
+        "--save_dir",
+        type=str,
+        default=None,
+        help="Directory where the converted train, valid and test splits will be saved",
+    )
+    convert_3d_parser.add_argument(
+        "--no_crop",
+        action="store_true",
+        default=False,
+        help="Don't apply the cropping mechanism to volumes before converting",
+    )
+
     args = parser.parse_args()
+    convert_func = None
 
     if args.command == "convert_2d":
         if args.root_dir is None:
             args.root_dir = (Path(DEFAULT_DATA_STORAGE) / "miccai").as_posix()
         if args.save_dir is None:
             args.save_dir = (Path(DEFAULT_DATA_STORAGE) / "miccai_2d").as_posix()
+        convert_func = convert_to_2d
 
-        convert_to_2d(args.root_dir, args.save_dir, "train", not args.no_crop)
-        convert_to_2d(args.root_dir, args.save_dir, "valid", not args.no_crop)
-        convert_to_2d(args.root_dir, args.save_dir, "test", not args.no_crop)
+    elif args.command == "convert_3d":
+        if args.root_dir is None:
+            args.root_dir = (Path(DEFAULT_DATA_STORAGE) / "miccai").as_posix()
+        if args.save_dir is None:
+            args.save_dir = (Path(DEFAULT_DATA_STORAGE) / "miccai_3d").as_posix()
+        convert_func = convert_to_3d
+
+    if convert_func is not None:
+        convert_func(args.root_dir, args.save_dir, "train", not args.no_crop)
+        convert_func(args.root_dir, args.save_dir, "valid", not args.no_crop)
+        convert_func(args.root_dir, args.save_dir, "test", not args.no_crop)

--- a/capstone/models/losses_3d.py
+++ b/capstone/models/losses_3d.py
@@ -1,0 +1,130 @@
+import torch
+import torch.nn.functional as F
+from capstone.models.losses import BaseLossWrapper, MultipleLossWrapper
+from capstone.models.temp import GeneralizedDiceLoss
+from capstone.utils import miccai
+from monai.losses.dice import DiceLoss
+from monai.losses.focal_loss import FocalLoss
+from monai.transforms import AsDiscrete
+
+WEIGHT = {
+    "Background": 1e-10,
+    "BrainStem": 0.007,
+    "Chiasm": 0.3296,
+    "Mandible": 0.0046,
+    "OpticNerve_L": 0.2619,
+    "OpticNerve_R": 0.3035,
+    "Parotid_L": 0.0068,
+    "Parotid_R": 0.0065,
+    "Submandibular_L": 0.0374,
+    "Submandibular_R": 0.0426,
+}  # Inverse pixel-frequency (Background is given no weight)
+
+
+class BaseLossWrapper3D(BaseLossWrapper):
+    """TODO"""
+
+    def __init__(self):
+        super(BaseLossWrapper3D, self).__init__()
+
+    def _process(self, input, target):
+        # assert target.ndim == 3, "Expected target of shape: (N, H, W)"
+        target = target.unsqueeze(dim=1)  # Shape: (N, 1, H, W)
+
+        return (input, target)
+
+
+class CrossEntropyWrapper3D(BaseLossWrapper3D):
+    """TODO"""
+
+    def __init__(self, **kwargs):
+        super(CrossEntropyWrapper3D, self).__init__()
+
+    @property
+    def loss_fx(self):
+        return F.cross_entropy
+
+    def _process(self, input, target):
+        return (input, target)
+
+
+class WeightedCrossEntropyWrapper3D(CrossEntropyWrapper3D):
+    """TODO"""
+
+    def __init__(self, **kwargs):
+        super(WeightedCrossEntropyWrapper3D, self).__init__()
+        self.weight = torch.as_tensor(list(WEIGHT.values()))
+
+    def forward(self, input, target):
+        input, target = self._process(input, target)
+        return self.loss_fx(input, target, weight=self.weight.type_as(input))
+
+
+class DiceLossWrapper3D(BaseLossWrapper3D):
+    """TODO"""
+
+    def __init__(self, reduction="mean"):
+        super(DiceLossWrapper3D, self).__init__()
+        self.reduction = reduction
+
+    @property
+    def loss_fx(self):
+        return DiceLoss(
+            include_background=False,
+            to_onehot_y=True,
+            softmax=True,
+            reduction=self.reduction,
+        )
+
+
+class GeneralizedDiceLossWrapper3D(BaseLossWrapper3D):
+    """TODO"""
+
+    def __init__(self, reduction="mean"):
+        super(GeneralizedDiceLossWrapper3D, self).__init__()
+        self.reduction = reduction
+
+    @property
+    def loss_fx(self):
+        return GeneralizedDiceLoss(
+            include_background=False,
+            to_onehot_y=True,
+            softmax=True,
+            reduction=self.reduction,
+        )
+
+
+class FocalLossWrapper3D(BaseLossWrapper3D):
+    """TODO"""
+
+    def __init__(self, reduction="mean"):
+        super(FocalLossWrapper3D, self).__init__()
+        self.reduction = reduction
+        self.n_classes = len(miccai.STRUCTURES) + 1  # Additional background
+
+    @property
+    def loss_fx(self):
+        return FocalLoss(reduction=self.reduction)
+
+    def _process(self, input, target):
+        # assert input.ndim == 4, "Expected input of shape: (N, C, H, W)"
+        # assert target.ndim == 3, "Expected target of shape: (N, H, W)"
+
+        expand = AsDiscrete(to_onehot=True, n_classes=self.n_classes)
+        target = expand(target.unsqueeze(dim=1))  # Shape: (N, C, H, W)
+
+        return (input, target)
+
+
+LOSSES = {
+    "CrossEntropy": CrossEntropyWrapper3D,
+    "WeightedCrossEntropy": WeightedCrossEntropyWrapper3D,
+    "Focal": FocalLossWrapper3D,
+    "Dice": DiceLossWrapper3D,
+    "GeneralizedDice": GeneralizedDiceLossWrapper3D,
+}
+
+
+class MultipleLossWrapper3D(MultipleLossWrapper):
+    def __init__(self, losses, exclude_missing=False):
+        super(MultipleLossWrapper3D, self).__init__(losses, exclude_missing)

--- a/capstone/models/metrics_3d.py
+++ b/capstone/models/metrics_3d.py
@@ -1,0 +1,20 @@
+from capstone.models.metrics import DiceMetricWrapper
+from monai.transforms import AsDiscrete
+
+
+class DiceMetricWrapper3D(DiceMetricWrapper):
+    """TODO"""
+
+    def __init__(self):
+        super(DiceMetricWrapper3D, self).__init__()
+
+    def _process(self, input, target):
+        # remove for now, consider making maybe 3D loss function
+        # assert input.ndim == 3, "Expected input of shape: (N, H, W)"
+        # assert target.ndim == 3, "Expected target of shape: (N, H, W)"
+
+        input = input.unsqueeze(dim=1)  # Shape: (N, 1, H, W)
+        target = target.unsqueeze(dim=1)  # Shape: (N, 1, H, W)
+
+        expand = AsDiscrete(to_onehot=True, n_classes=self.n_classes)
+        return expand(input), expand(target)  # Shape: (N, C, H, W) - binarized

--- a/capstone/training/base_trainer_3d.py
+++ b/capstone/training/base_trainer_3d.py
@@ -1,0 +1,254 @@
+from argparse import ArgumentParser
+from typing import List
+
+import pytorch_lightning as pl
+import torch
+import torch.optim as optim
+from capstone.data.data_module import MiccaiDataModule3D
+from capstone.models import UNet
+from capstone.models.losses_3d import MultipleLossWrapper3D
+from capstone.models.metrics_3d import DiceMetricWrapper3D
+from capstone.paths import DEFAULT_DATA_STORAGE
+from capstone.training.utils import _squash_masks_3D, _squash_predictions
+from capstone.utils import miccai
+from pytorch_lightning import Trainer, seed_everything
+from pytorch_lightning.loggers import WandbLogger
+from pytorch_lightning.utilities import rank_zero_only
+
+# from capstone.training.callbacks import ExamplesLoggingCallback
+
+SEED = 12342
+
+
+class BaseUNet3D(pl.LightningModule):
+    def __init__(
+        self,
+        filters: List = [16, 32, 64, 128, 256],
+        use_res_units: bool = False,
+        downsample: bool = False,
+        lr: float = 1e-3,
+        loss_fx: list = ["CrossEntropy"],
+        exclude_missing: bool = False,
+        **kwargs,
+    ) -> None:
+        super().__init__()
+
+        assert isinstance(loss_fx, list), "This module expects a list of loss functions"
+        loss_fx.sort()  # To have consistent order of loss functions
+
+        self.save_hyperparameters(
+            "batch_size",
+            "transform_degree",
+            "filters",
+            "use_res_units",
+            "downsample",
+            "lr",
+            "loss_fx",
+            "exclude_missing",
+        )
+        # self.conv1x1 = nn.Conv2d(in_channels=3, out_channels=1, kernel_size=1, stride=1)
+        self.unet = self._construct_model()
+        self.loss_func = MultipleLossWrapper3D(
+            losses=loss_fx, exclude_missing=exclude_missing
+        )
+        self.dice_score = DiceMetricWrapper3D()
+
+    @property
+    def _n_classes(self):
+        return len(miccai.STRUCTURES) + 1  # Additional background
+
+    def _construct_model(self):
+        # in_channels = (
+        #    1 if self.hparams.downsample else 3
+        # )  # assuming transform_degree in [1, 2, 3, 4]
+        strides = [2, 2, 2, 2]  # Default for 5-layer UNet
+        in_channels = 1  # change after adding 3D transformations. Now not using any transformations.
+
+        return UNet(
+            dimensions=3,
+            in_channels=in_channels,
+            out_channels=self._n_classes,
+            channels=self.hparams.filters,
+            strides=strides,
+            num_res_units=2,
+        )
+
+    def forward(self, x):
+        if self.hparams.downsample:
+            x = self.conv1x1(x)
+        x = self.unet(x)
+        return x
+
+    def training_step(self, batch, batch_idx):
+        images, masks, mask_indicator, prediction, loss = self._shared_step(
+            batch, is_training=True
+        )
+        return loss
+
+    def validation_step(self, batch, batch_idx):
+        images, masks, mask_indicator, prediction, loss = self._shared_step(
+            batch, is_training=False
+        )
+
+    def _shared_step(self, batch, is_training: bool):
+        # Image : Bx1xHxWxD (4x1x256x256x96 usually) #Masks : Bx9xHxWxD (1x9x256x256x96 usually)
+        (images, masks, mask_indicator) = batch
+
+        masks = _squash_masks_3D(
+            masks, self._n_classes, self.device
+        )  # Masks: BxHxWxD (4x256x256x96 usually) has number in [0-9] indicating one of 10 classes
+        mask_indicator = mask_indicator.type_as(images)
+        prefix = "train" if is_training else "val"
+
+        prediction = self.forward(
+            images
+        )  # Prediction: Bx10xHxWxD (4x10x256x256x96 usually)
+
+        loss_dict = self.loss_func(
+            input=prediction, target=masks, mask_indicator=mask_indicator
+        )
+        total_loss = torch.stack(list(loss_dict.values())).sum()
+
+        for name, loss_value in loss_dict.items():
+            self.log(
+                f"{name} Loss ({prefix})", loss_value, on_step=False, on_epoch=True,
+            )
+        self._log_dice_scores(prediction, masks, mask_indicator, prefix)
+        return images, masks, mask_indicator, prediction, total_loss
+
+    def configure_optimizers(self):
+        return optim.Adam(self.parameters(), lr=self.hparams.lr)
+
+    def _log_dice_scores(self, prediction, masks, mask_indicator, prefix):
+        pred = prediction.clone()
+        self.eval()
+        with torch.no_grad():
+            # if self.hparams.exclude_missing:                  "<---Do later
+            # No indicator for background
+            #   pred[:, 1:, :, :] = pred[:, 1:, :, :] * mask_indicator[:, :, None, None]
+            pred = _squash_predictions(pred)  # Shape: (N, H, W)
+            dice_mean, dice_per_class = self.dice_score(pred, masks)
+            for structure, score in zip(miccai.STRUCTURES, dice_per_class):
+                self.log(
+                    f"{structure} Dice ({prefix})", score, on_step=False, on_epoch=True,
+                )
+            self.log(
+                f"Mean Dice Score ({prefix})", dice_mean, on_step=False, on_epoch=True,
+            )
+        self.train()
+
+    @staticmethod
+    def add_model_specific_args(parent_parser):
+        """The parameters specific to the model/data processing."""
+        parser = ArgumentParser(parents=[parent_parser], add_help=False)
+        parser.add_argument(
+            "--batch_size", type=int, default=1, help="Batch size",
+        )
+        parser.add_argument(
+            "--transform_degree",
+            type=int,
+            default=0,
+            help="The degree of transforms/data augmentation to be applied",
+        )
+        parser.add_argument(
+            "--filters",
+            nargs=5,
+            type=int,
+            default=[64, 128, 256, 512, 1024],
+            help="A sqeuence of number of filters for the downsampling path in UNet",
+        )
+        parser.add_argument(
+            "--use_res_units",
+            action="store_true",
+            default=False,
+            help="For using residual units in UNet",
+        )
+        parser.add_argument(
+            "--downsample",
+            action="store_true",
+            default=False,
+            help="For using a 1x1 convolution to downsample the input before UNet",
+        )
+        parser.add_argument(
+            "--lr", type=float, default=1e-3, help="Learning rate",
+        )
+        parser.add_argument(
+            "--loss_fx",
+            nargs="+",
+            type=str,
+            default="CrossEntropy",
+            help="Loss function",
+        )
+        parser.add_argument(
+            "--exclude_missing",
+            action="store_true",
+            default=False,
+            help="Exclude missing annotations from loss computation as described in AnatomyNet",
+        )
+        return parser
+
+
+class WandbLoggerPatch(WandbLogger):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @rank_zero_only
+    def log_hyperparams(self, params):
+        params = self._convert_params(params)
+        params = self._flatten_dict(params)
+        params = self._sanitize_callable_params(params)
+        params = self._sanitize_params(params)
+        self.experiment.config.update(params, allow_val_change=True)
+
+
+def main(args):
+    seed_everything(SEED)
+    dict_args = vars(args)
+
+    # Data
+    miccai_3d = MiccaiDataModule3D(**dict_args)
+
+    # Model
+    model = BaseUNet3D(**dict_args)
+
+    # Trainer
+    trainer = Trainer.from_argparse_args(args)
+
+    trainer.fit(model=model, datamodule=miccai_3d)
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--use_wandb",
+        action="store_true",
+        default=False,
+        help="Use Weights & Biases for logging",
+    )
+    parser.add_argument(
+        "--experiment_name",
+        type=str,
+        default="UNet 3D",
+        help="Experiment name for Weights & Biases",
+    )
+
+    parser = BaseUNet3D.add_model_specific_args(parser)
+    parser = Trainer.add_argparse_args(parser)
+
+    args = parser.parse_args()
+
+    if isinstance(args.loss_fx, str):
+        args.loss_fx = [args.loss_fx]
+
+    if args.default_root_dir is None:
+        args.default_root_dir = DEFAULT_DATA_STORAGE
+
+    if args.use_wandb:
+        args.logger = WandbLoggerPatch(
+            name=args.experiment_name,
+            save_dir=DEFAULT_DATA_STORAGE,
+            project="ct-image-segmentation",
+        )
+        # args.callbacks = [ExamplesLoggingCallback(seed=SEED)]
+
+    main(args)

--- a/capstone/training/utils.py
+++ b/capstone/training/utils.py
@@ -14,3 +14,9 @@ def _squash_masks(masks, n_classes, device):
 
 def _squash_predictions(preds):
     return torch.softmax(preds, dim=1).argmax(dim=1)  # Shape: (N, H, W)
+
+
+def _squash_masks_3D(masks, n_classes, device):
+    _temp = torch.arange(1, n_classes, device=device)
+    masks = (masks * _temp[None, :, None, None, None]).max(dim=1).values
+    return masks

--- a/capstone/transforms/predefined_3d.py
+++ b/capstone/transforms/predefined_3d.py
@@ -1,0 +1,7 @@
+import albumentations as A
+from capstone.transforms.transforms_3d import Resize3D, ToTensorV3
+
+windowed_degree_0 = {
+    "train": A.Compose([Resize3D(), ToTensorV3()]),
+    "test": A.Compose([Resize3D(), ToTensorV3()]),
+}

--- a/capstone/transforms/transforms_3d.py
+++ b/capstone/transforms/transforms_3d.py
@@ -1,0 +1,50 @@
+from typing import List, Tuple
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from albumentations.core.transforms_interface import DualTransform, ImageOnlyTransform
+from scipy.ndimage import zoom
+
+
+class Resize3D(DualTransform):
+    def __init__(self, size=(96, 256, 256), always_apply=True, p=1.0):
+        # DxHxW. Matches our data quite closely (only need to interpolate a little) and works with the existing UNet
+        super(Resize3D, self).__init__(always_apply=True, p=1.0)
+        self.size = size
+
+    def apply(self, image: np.ndarray, **params) -> np.ndarray:
+        image = torch.from_numpy(image).unsqueeze(0)
+        resized = F.interpolate(image, self.size).squeeze(0)
+        return resized
+
+    def apply_to_mask(self, image: np.ndarray, **params) -> np.ndarray:
+        image = torch.from_numpy(image).unsqueeze(0).unsqueeze(0)
+        resized = F.interpolate(image, self.size).squeeze(0).squeeze(0)
+        return resized
+
+    def apply_to_bbox(self, bbox, **params):
+        pass
+
+    def apply_to_keypoint(self, keypoint, **params):
+        pass
+
+    def get_transform_init_args_names(self) -> List:
+        return []
+
+
+class ToTensorV3(DualTransform):
+    def __init__(self, always_apply=True, p=1.0):
+        super(ToTensorV3, self).__init__(always_apply=always_apply, p=p)
+
+    def apply(self, img, **params):
+        return img.permute(0, 2, 3, 1)
+
+    def apply_to_mask(self, mask, **params):
+        return mask.permute(1, 2, 0)
+
+    def get_transform_init_args_names(self):
+        return ("transpose_mask",)
+
+    def get_params_dependent_on_targets(self, params):
+        return {}


### PR DESCRIPTION
The following PR segregates the 2D and 3D related code modules. Following are the reasons:

1. Inevitably, there will be differences between how 2D and 3D data is handled (its improbable for the same code to work for both). If everything is combined in the same file - updates to the 3D version may affect the 2D version. (maybe not now, but at some point, it definitely will).
2. Having separate code modules might introduce some redundancy, but we can treat 2D and 3D as being completely individual. Running `base_trainer_3d.py` will always use the 3D data, the 3D transforms and the 3D loss functions/metrics. Since the loss functions could potentially work for both 3D and 2D, finding mistakes would be tedious as we would not know exactly which format of data caused the issue.
3. 3D workflow could have its own possible parameters (like resampling). These will be logged to W&B even in the 2D case, where it makes no sense. Having them in separate modules gives the flexibility to use entirely different W&B dashboards to track the experiments.
4. Personally, managing the code will be much more simple. We don't have to worry about how a specific change will affect 2D or 3D.

The code in the PR is copied exactly from #41 

Some minor differences:

1. There's no argument specifying the dimension (no '2D' or '3D'): Instead, 3D code resides in its own module. For example - `base_trainer_3d.py`, `predefined_3d.py`.
2. The `process_miccai.py` file follows the same pattern as before:
	- `python process_miccai.py convert_2d` -> Convert to 2D
	- `python process_miccai.py convert_3d` -> Convert to 3D
3. The loss functions and metrics for 3D are in `losses_3d.py` and `metrics_3d.py`. Again, the code for 2D and 3D can always be merged later, if things work fine. But for now, keeping them separate will make it easier to make updates/modifications if needed.
